### PR TITLE
Add FastAPI endpoint tests

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,45 +1,32 @@
-﻿# app/logging_config.py - Structured Logging Configuration
+# app/logging_config.py - Structured Logging Configuration
 import logging
 import sys
 import os
 from pythonjsonlogger import jsonlogger
 
 def setup_logging():
-    \"\"\"Setup structured logging for production\"\"\"
-    
-    # Create custom formatter
+    """Setup structured logging for production"""
+
     class CustomJsonFormatter(jsonlogger.JsonFormatter):
         def add_fields(self, log_record, record, message_dict):
             super().add_fields(log_record, record, message_dict)
             log_record['service'] = 'diabetes-api'
             log_record['environment'] = os.getenv('ENVIRONMENT', 'development')
-    
-    # Configure root logger
+
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
-    
-    # Remove existing handlers
+
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
-    
-    # Create handler
+
     handler = logging.StreamHandler(sys.stdout)
-    
-    # Use JSON formatter for production, simple for development
+
     if os.getenv('ENVIRONMENT') == 'production':
-        formatter = CustomJsonFormatter(
-            '%(asctime)s %(name)s %(levelname)s %(message)s'
-        )
+        formatter = CustomJsonFormatter('%(asctime)s %(name)s %(levelname)s %(message)s')
     else:
-        formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-        )
-    
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    
-    return logger
 
-# Usage: Add this to the top of main.py after imports:
-# from app.logging_config import setup_logging
-# logger = setup_logging()
+    return logger

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,48 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Create TestClient with patched model loading."""
+    import app.deps as deps
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("mlflow disabled in tests")
+
+    monkeypatch.setattr(deps.mlflow.pyfunc, "load_model", _raise)
+
+    with TestClient(app) as c:
+        yield c
+
+
+def test_health_endpoint(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert {"status", "model_status", "version", "environment"} <= data.keys()
+
+
+def test_predict_probability(client):
+    payload = {
+        "race": "Caucasian",
+        "gender": "Female",
+        "age": "[60-70)",
+        "time_in_hospital": 7,
+        "num_medications": 15,
+        "number_outpatient": 0,
+        "number_emergency": 1,
+        "number_inpatient": 0,
+        "number_diagnoses": 9,
+        "a1c_result": ">7",
+        "max_glu_serum": "None",
+        "change": "Ch",
+        "diabetesMed": "Yes",
+    }
+    response = client.post("/predict", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert 0.0 <= data["probability"] <= 1.0


### PR DESCRIPTION
## Summary
- fix logging_config syntax
- add tests for /health and /predict endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844cfd89efc83338d32e9dc639ae33a