### PR TITLE
Switch KS drift check to p-values

### DIFF
--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,8 +1,13 @@
 import os
 import sys
-import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-import pandas as pd
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
 import numpy as np
+import pandas as pd
+import pytest
+
 from monitoring.data_drift import compute_kl_divergence, compute_ks_statistic, detect_drift
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -11,20 +16,21 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 def test_kl_divergence_zero():
     df1 = pd.DataFrame({"a": np.random.normal(0, 1, 1000)})
     df2 = pd.DataFrame({"a": np.random.normal(0, 1, 1000)})
-    kl = compute_kl_divergence(df1, df2, ['a'])
-    assert kl == 0.0
+    kl = compute_kl_divergence(df1, df2, ["a"])
+    assert kl < 1.0
 
 
 def test_ks_statistic_zero():
     df1 = pd.DataFrame({"a": np.random.normal(0, 1, 1000)})
     df2 = pd.DataFrame({"a": np.random.normal(0, 1, 1000)})
-    ks = compute_ks_statistic(df1, df2, ['a'])
-    assert ks == 0.0
+    p_val = compute_ks_statistic(df1, df2, ["a"])
+    assert p_val > 0.05
 
 
 def test_detect_drift_threshold():
     np.random.seed(0)
-    ref = pd.DataFrame({'a': np.random.normal(0, 1, 1000)})
-    cur = pd.DataFrame({'a': np.random.normal(5, 1, 1000)})
-    assert detect_drift(ref, cur, ['a'], method='ks', threshold=0.1)
-    assert detect_drift(ref, cur, ['a'], method='kl', threshold=0.1)
+    ref = pd.DataFrame({"a": np.random.normal(0, 1, 1000)})
+    cur = pd.DataFrame({"a": np.random.normal(5, 1, 1000)})
+    assert detect_drift(ref, cur, ["a"], method="ks", threshold=0.05)
+    assert detect_drift(ref, cur, ["a"], method="kl", threshold=0.02)
+


### PR DESCRIPTION
## Summary
- use KS test p-values for drift detection
- adjust drift unit tests for KL and KS

## Testing
- `pytest tests/test_drift.py -q`
- `pytest -k drift -q`


------
https://chatgpt.com/codex/tasks/task_e_68460b9550e48333abb1b6aa684967f8