### PR TITLE
Add Prometheus service for API metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,17 @@ services:
       timeout: 10s
       retries: 3
 
+  prometheus:
+    image: prom/prometheus:v2.49.1
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      - api
+
   grafana:
     image: grafana/grafana:10.2.0
     ports:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'fastapi'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['api:8000']


### PR DESCRIPTION
## Summary
- add Prometheus service to compose setup
- mount scraping config for FastAPI metrics
- confirm Grafana data source still points to Prometheus

## Testing
- `pip install fastapi httpx numpy pandas pytest prometheus_client scipy mlflow python-json-logger`
- `pytest -q` *(fails: ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6850bb284f18833388dfaafb0bdced8a