### PR TITLE
Remove reload default from API Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-CMD ["uvicorn", "app.main:app", "--host=0.0.0.0", "--port=8000", "--reload"]
+# Optionally enable auto-reload by setting UVICORN_RELOAD to "--reload"
+ENV UVICORN_RELOAD=""
+CMD ["sh", "-c", "uvicorn app.main:app --host=0.0.0.0 --port=8000 ${UVICORN_RELOAD}"]


### PR DESCRIPTION
## Summary
- disable uvicorn reload by default
- add `UVICORN_RELOAD` env var to enable reload

## Testing
- `pytest --maxfail=1 -q` *(fails: PytestConfigWarning and KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6850bb371fe083338864368d5fe2877e