### PR TITLE
Add pre-commit and update README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+minimum_pre_commit_version: '2.20.0'
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
+    hooks:
+      - id: ruff
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ For Testing (No Changes Needed):
 ✅ Local development - All defaults work
 ✅ Docker Compose - Uses localhost URLs
 ✅ Dummy model - No real model needed
+
+## Installation
+
+1. Install [Poetry](https://python-poetry.org/docs/#installation).
+2. Install project dependencies:
+   ```bash
+   poetry install
+   ```
+3. Install pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
 """
 
 


### PR DESCRIPTION
## Summary
- add pre-commit configuration for black, ruff and pytest
- document how to install dependencies and hooks

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6850bb3b84288333a9c84cb83ae71bcb