### PR TITLE
Add install-tools target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup dev health-check test lint build clean
+.PHONY: help setup dev health-check test lint build clean install-tools
 
 help:
 	@echo Available commands:
@@ -36,3 +36,6 @@ clean:
 
 stop:
 	docker-compose down
+
+install-tools:
+	poetry run pip install --upgrade pre-commit ruff black


### PR DESCRIPTION
## Summary
- add `install-tools` command to make sure developer tools are installed

## Testing
- `poetry install --with dev`
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6850c1b214d88333894d91750b3a89ae