### PR TITLE
Fix Minio env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
     volumes:
       - minio_data:/data
     healthcheck:


### PR DESCRIPTION
## Summary
- use `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` in docker-compose

## Testing
- `pytest -k 'drift' -q` *(fails: assert 1.294... < 1.0)*

------
https://chatgpt.com/codex/tasks/task_e_6850c1785200833383a8a4ac631dc5a9