### PR TITLE
Add Terraform variables

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,10 @@
+variable "environment" {
+  description = "Deployment environment (e.g., dev, prod)"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}


### PR DESCRIPTION
## Summary
- define `environment` and `vpc_cidr` variables for Terraform

## Testing
- `terraform init` *(fails: Error accessing remote module registry)*
- `terraform apply -var=environment=prod` *(fails: initialization required)*
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853a69301408333aab53e6b85f89473