### PR TITLE
Add Minio bucket setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,12 @@ class ModelRegistry:
 ### **Deployment**
 - [ ] Infrastructure provisioned via Terraform
 - [ ] Secrets properly configured
+- [ ] `mlflow-artifacts` bucket created in Minio before starting MLflow
+  ```bash
+  mc alias set minio http://localhost:9000 minioadmin minioadmin
+  mc mb minio/mlflow-artifacts
+  ```
+  See the [MLflow S3 storage guide](https://mlflow.org/docs/latest/ml/tracking.html#artifact-stores) for additional options.
 - [ ] SSL certificates installed
 - [ ] Database migrations applied
 - [ ] Application deployed via Helm


### PR DESCRIPTION
## Summary
- mention creating `mlflow-artifacts` bucket during deployment
- reference MLflow docs for S3 storage

## Testing
- `pre-commit run --files README.md` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68586e88a7208333813f3f9d2f223851