### PR TITLE
Fix production config placeholders

### DIFF
--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,13 +1,13 @@
-﻿# config/production.yaml
+# config/production.yaml
 environment: production
 debug: false
 log_level: WARNING
 
 database:
-  url: \
+  url: postgresql://postgres:postgres@postgres.mlops.svc.cluster.local:5432/mlflow
   
 mlflow:
-  tracking_uri: \
+  tracking_uri: http://mlflow.mlops.svc.cluster.local:5000
   experiment_name: diabetes-prod
 
 model:


### PR DESCRIPTION
## Summary
- remove UTF-8 BOM from `config/production.yaml`
- fill `database.url` and `mlflow.tracking_uri`

## Testing
- `make test` *(fails: ModuleNotFoundError for httpx and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68586fdc15048333ac67831e3e1112bf