### PR TITLE
Implement Slack alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,8 @@ The Helm chart expects a secret named `diabetes-secrets` with the keys
 `database-url`, `mlflow-uri`, and `jwt-secret`. These values populate the
 `DATABASE_URL`, `MLFLOW_TRACKING_URI`, and `JWT_SECRET` environment variables in
 the deployment.
+To enable Slack alerts, provide a `SLACK_WEBHOOK_URL` environment variable
+containing your Slack incoming webhook.
 
 #### **5. EKS Cluster Creation**
 ```bash

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -17,3 +17,7 @@ model:
 monitoring:
   enable_drift_detection: true
   drift_threshold: 0.1
+
+alerting:
+  backend: slack
+  slack_webhook_env: SLACK_WEBHOOK_URL

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -17,6 +17,10 @@ model:
 monitoring:
   enable_drift_detection: true
   drift_threshold: 0.05
+
+alerting:
+  backend: slack
+  slack_webhook_env: SLACK_WEBHOOK_URL
   
 security:
   enable_auth: true

--- a/monitoring/alerts.py
+++ b/monitoring/alerts.py
@@ -1,37 +1,44 @@
-import smtplib
+import os
 import logging
-from email.mime.text import MIMEText
 from typing import Dict, Any
+
+import requests
 
 logger = logging.getLogger(__name__)
 
+
 class AlertManager:
-    def __init__(self, smtp_server: str = None, email: str = None):
-        self.smtp_server = smtp_server
-        self.email = email
-    
-    def send_alert(self, title: str, message: str, severity: str = 'INFO'):
+    def __init__(self, slack_webhook_url: str | None = None):
+        self.slack_webhook_url = slack_webhook_url or os.getenv("SLACK_WEBHOOK_URL")
+
+    def send_alert(self, title: str, message: str, severity: str = "INFO"):
         """Send alert via email/slack/etc"""
-        alert_msg = f'[{severity}] {title}: {message}'
+        alert_msg = f"[{severity}] {title}: {message}"
         logger.warning(alert_msg)
-        
-        # TODO: Implement actual alerting (email, Slack, PagerDuty)
-        if severity == 'CRITICAL':
-            print(f'🚨 CRITICAL ALERT: {alert_msg}')
-    
+
+        if self.slack_webhook_url:
+            try:
+                requests.post(
+                    self.slack_webhook_url,
+                    json={"text": alert_msg},
+                    timeout=5,
+                )
+            except Exception as e:  # pragma: no cover - log only
+                logger.error("Failed to send Slack alert: %s", e)
+        if severity == "CRITICAL" and not self.slack_webhook_url:
+            print(f"🚨 CRITICAL ALERT: {alert_msg}")
+
     def check_model_performance(self, metrics: Dict[str, Any]):
         """Alert if model performance degrades"""
-        auc = metrics.get('auc', 0)
-        
+        auc = metrics.get("auc", 0)
+
         if auc < 0.6:
             self.send_alert(
-                'Model Performance Degraded',
-                f'Model AUC dropped to {auc:.3f}',
-                'CRITICAL'
+                "Model Performance Degraded",
+                f"Model AUC dropped to {auc:.3f}",
+                "CRITICAL",
             )
         elif auc < 0.7:
             self.send_alert(
-                'Model Performance Warning', 
-                f'Model AUC is {auc:.3f}',
-                'WARNING'
+                "Model Performance Warning", f"Model AUC is {auc:.3f}", "WARNING"
             )

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,17 @@
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import responses
+
+from monitoring.alerts import AlertManager
+
+
+@responses.activate
+def test_send_alert_slack():
+    webhook = "https://hooks.slack.com/services/test"
+    responses.add(responses.POST, webhook, json={}, status=200)
+    manager = AlertManager(slack_webhook_url=webhook)
+    manager.send_alert("Test", "hello", "INFO")
+    assert len(responses.calls) == 1
+    assert "Test" in responses.calls[0].request.body.decode()


### PR DESCRIPTION
## Summary
- integrate Slack webhook with `AlertManager`
- allow configuring Slack credentials via YAML files
- document `SLACK_WEBHOOK_URL` environment variable
- add unit test for Slack alerts

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_685a0c0f899c8333b61eef044ee05026