### PR TITLE
Fix smoke test service name

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -128,8 +128,8 @@ jobs:
     
     - name: Run smoke tests
       run: |
-        kubectl wait --for=condition=ready pod -l app=diabetes-${{ env.ENVIRONMENT }} --timeout=300s
-        kubectl port-forward svc/diabetes-${{ env.ENVIRONMENT }} 8080:8000 &
+        kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=diabetes-${{ env.ENVIRONMENT }} --timeout=300s
+        kubectl port-forward svc/diabetes-${{ env.ENVIRONMENT }}-diabetes-mlops 8080:8000 &
         sleep 10
         curl -f http://localhost:8080/health || exit 1
         curl -f http://localhost:8080/metrics || exit 1

--- a/implementation_guide.md
+++ b/implementation_guide.md
@@ -491,7 +491,7 @@ kubectl get pods -n dev
 kubectl get svc -n dev
 
 # Port forward to test locally
-kubectl port-forward svc/diabetes-dev 8080:8000 -n dev
+kubectl port-forward svc/diabetes-dev-diabetes-mlops 8080:8000 -n dev
 
 # Test the deployed API
 curl http://localhost:8080/health


### PR DESCRIPTION
## Summary
- update wait label to use Helm's instance label
- port-forward to the correct Helm release service name
- update implementation guide to match service name

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: prometheus_client)*

------
https://chatgpt.com/codex/tasks/task_e_685a0c0d23908333b09862fed484bed4