### PR TITLE
Improve CORS configuration

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -5,10 +5,22 @@ metadata:
   name: {{ include "diabetes-mlops.fullname" . }}
   labels:
     {{- include "diabetes-mlops.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    # CORS configuration
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+    nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length,Content-Range"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-max-age: "3600"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      if ($request_method = 'OPTIONS') {
+        return 204;
+      }
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}


### PR DESCRIPTION
## Summary
- adjust FastAPI CORS settings to use `ENVIRONMENT` variable
- expose CORS headers and preflight caching
- configure CORS annotations for Kubernetes ingress
- update exception raising style to satisfy ruff

## Testing
- `timeout 30s poetry run pytest -q` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686f0c0c72d483339228ffc0862478bc