### PR TITLE
CI: use the AWS access-key secrets that actually exist; skip image builds on PRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,9 +7,7 @@ on:
   pull_request:
     branches: [main]
 
-# Required for OIDC role assumption (aws-actions/configure-aws-credentials)
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -60,6 +58,8 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    # Images are only built and pushed on merge/tag, not for every PR
+    if: github.event_name != 'pull_request'
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}
       image-digest: ${{ steps.build.outputs.digest }}
@@ -74,7 +74,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Login to ECR
@@ -117,7 +118,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Update kubeconfig

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ feature_importance.csv
 # OS
 .DS_Store
 Thumbs.db
+diabetes-mlops-environment-*.txt

--- a/README.md
+++ b/README.md
@@ -88,12 +88,13 @@ run with zero infrastructure and never import MLflow.
 
 GitHub Actions ([.github/workflows/ci-cd.yml](.github/workflows/ci-cd.yml)):
 
+- **pull request** → test job only (lint + full suite); no image is built
 - **push to main** → test → build/push image to ECR (`sha-<sha>` tag) → deploy
   to the `development` namespace on `conai-cluster`
 - **tag `v*`** → same, but deploys to `production` on `prod-diabetes-eks`
-- Auth is keyless (OIDC role assumption); required repo secrets:
-  `AWS_ACCOUNT_ID`, `AWS_ROLE_ARN`, `SLACK_WEBHOOK`; optional repo variables:
-  `MLFLOW_URI`, `JWKS_URL`, `ISSUER`.
+- Required repo secrets (already configured): `AWS_ACCOUNT_ID`,
+  `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `SLACK_WEBHOOK`; optional repo
+  variables: `MLFLOW_URI`, `JWKS_URL`, `ISSUER`.
 
 The Helm chart creates the `diabetes-secrets` Secret from values by default
 (`secrets.create: true`); set it to `false` to manage the secret externally:


### PR DESCRIPTION
Fixes the `build` job failure on main (`Credentials could not be loaded`).

Root cause: the workflow (original and current) authenticated via OIDC `role-to-assume: secrets.AWS_ROLE_ARN`, but this repo no longer has an `AWS_ROLE_ARN` secret, it has `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. So the build job failed at the credentials step in every run, before and after the review fixes.

- Both AWS credential steps now use the access-key secrets — no AWS console work needed.
- The build job is skipped on `pull_request` events: PRs run lint + tests only; images build and deploy on merge to main or a `v*` tag.
- README deployment section updated to match.