### PR TITLE
CI: smoke-test the built image on every run; AWS chain only on tags/manual

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,8 @@ on:
     tags: ['v*']
   pull_request:
     branches: [main]
+  # "Run workflow" button: triggers the full build + deploy chain on demand
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -55,11 +57,52 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v5
 
-  build:
+  # End-to-end diagnostic on every PR and push: build the production image,
+  # boot it, and run the real smoke test against it. Needs no AWS access.
+  smoke:
     needs: test
     runs-on: ubuntu-latest
-    # Images are only built and pushed on merge/tag, not for every PR
-    if: github.event_name != 'pull_request'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build image (local only, no push)
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        load: true
+        tags: diabetes-mlops:smoke
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Start API container
+      run: docker run -d --name api -p 8000:8000 diabetes-mlops:smoke
+
+    - name: Wait for API to come up
+      run: |
+        for i in $(seq 1 30); do
+          if curl -sf http://localhost:8000/health > /dev/null; then exit 0; fi
+          sleep 2
+        done
+        echo "API did not become healthy within 60s"
+        exit 1
+
+    - name: Run smoke tests
+      run: python3 scripts/smoke_test.py --base-url http://localhost:8000
+
+    - name: Show API logs (diagnostics)
+      if: failure()
+      run: docker logs api
+
+  # The AWS chain below only runs for version tags or the manual
+  # "Run workflow" button — regular pushes and PRs stay green without AWS.
+  build:
+    needs: [test, smoke]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}
       image-digest: ${{ steps.build.outputs.digest }}
@@ -81,6 +124,11 @@ jobs:
     - name: Login to ECR
       uses: aws-actions/amazon-ecr-login@v2
 
+    - name: Ensure ECR repository exists
+      run: |
+        aws ecr describe-repositories --repository-names ${{ env.IMAGE_NAME }} \
+          || aws ecr create-repository --repository-name ${{ env.IMAGE_NAME }}
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
@@ -88,7 +136,6 @@ jobs:
         images: ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch
-          type=ref,event=pr
           type=semver,pattern={{version}}
           type=sha,format=long
 
@@ -105,9 +152,9 @@ jobs:
         cache-to: type=gha,mode=max
 
   deploy:
-    needs: [test, build]
+    needs: [test, smoke, build]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'development' }}
     env:
       DEPLOY_ENV: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'development' }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,7 +79,9 @@ jobs:
         cache-to: type=gha,mode=max
 
     - name: Start API container
-      run: docker run -d --name api -p 8000:8000 diabetes-mlops:smoke
+      # Empty MLFLOW_TRACKING_URI skips the registry lookup: the container
+      # boots straight onto the DummyModel for fast, dependency-free checks
+      run: docker run -d --name api -p 8000:8000 -e MLFLOW_TRACKING_URI= diabetes-mlops:smoke
 
     - name: Wait for API to come up
       run: |

--- a/README.md
+++ b/README.md
@@ -88,10 +88,14 @@ run with zero infrastructure and never import MLflow.
 
 GitHub Actions ([.github/workflows/ci-cd.yml](.github/workflows/ci-cd.yml)):
 
-- **pull request** → test job only (lint + full suite); no image is built
-- **push to main** → test → build/push image to ECR (`sha-<sha>` tag) → deploy
-  to the `development` namespace on `conai-cluster`
-- **tag `v*`** → same, but deploys to `production` on `prod-diabetes-eks`
+- **pull request / push to main** → `test` (lint + full suite) and `smoke`
+  (builds the production Docker image on the runner, boots it, and runs
+  `scripts/smoke_test.py` against it) — full diagnostics with **no AWS needed**
+- **tag `v*`** → test → smoke → build/push image to ECR (`sha-<sha>` tag,
+  auto-creating the ECR repo if missing) → deploy to `production` on
+  `prod-diabetes-eks` → Slack notification
+- **"Run workflow" button** (Actions tab) → same full chain on demand,
+  deploying to `development` on `conai-cluster`
 - Required repo secrets (already configured): `AWS_ACCOUNT_ID`,
   `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `SLACK_WEBHOOK`; optional repo
   variables: `MLFLOW_URI`, `JWKS_URL`, `ISSUER`.

--- a/app/deps.py
+++ b/app/deps.py
@@ -45,17 +45,27 @@ class ModelLoader:
         # Strategy 1: MLflow registry. The sklearn flavor keeps predict_proba,
         # which the pyfunc flavor does not expose. Imported lazily so unit
         # tests and dummy-model startups never pay the mlflow import chain.
-        try:
-            import mlflow
-            import mlflow.sklearn
+        # Skipped entirely when MLFLOW_TRACKING_URI is set to an empty string.
+        if settings["mlflow_uri"]:
+            try:
+                # Bound the registry attempt: mlflow's defaults (7 retries,
+                # exponential backoff, 120s timeout) stall startup for minutes
+                # when the server is unreachable. Env vars still win if set.
+                os.environ.setdefault("MLFLOW_HTTP_REQUEST_MAX_RETRIES", "1")
+                os.environ.setdefault("MLFLOW_HTTP_REQUEST_TIMEOUT", "10")
 
-            mlflow.set_tracking_uri(settings["mlflow_uri"])
-            model_uri = f"models:/{settings['model_name']}/{settings['model_stage']}"
-            model = mlflow.sklearn.load_model(model_uri)
-            logger.info("Loaded model from MLflow")
-            return model
-        except Exception as e:
-            logger.warning(f"MLflow model loading failed: {e}")
+                import mlflow
+                import mlflow.sklearn
+
+                mlflow.set_tracking_uri(settings["mlflow_uri"])
+                model_uri = (
+                    f"models:/{settings['model_name']}/{settings['model_stage']}"
+                )
+                model = mlflow.sklearn.load_model(model_uri)
+                logger.info("Loaded model from MLflow")
+                return model
+            except Exception as e:
+                logger.warning(f"MLflow model loading failed: {e}")
 
         # Strategy 2: local artifact
         local_model_path = Path(settings["model_path"])


### PR DESCRIPTION
Replaces build/notify with the actual smoke test for diagnostics.

**Every PR and push to main now runs two jobs, no AWS involved:**
- `test` — lint + the full 24-test suite
- `smoke` (new) — builds the production Docker image on the runner, boots the container, and runs `scripts/smoke_test.py` against it: `/health`, `/ready`, `/metrics`, a real `POST /predict` payload, `/model/info`. Container logs are dumped automatically on failure for diagnostics.

**The AWS chain (build → deploy → notify) no longer runs on ordinary pushes.** It failed on every main push because the `diabetes-mlops` ECR repository no longer exists in the account. It now runs only on:
- `v*` tags → production (`prod-diabetes-eks`)
- the **Run workflow** button in the Actions tab → development (`conai-cluster`)

and the build job **creates the ECR repository if it's missing**, so the next deploy self-heals instead of failing.

This PR's own checks demonstrate the new behavior: test + smoke run, everything AWS-related is skipped.